### PR TITLE
Avoid conflicting distribution name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-DISTNAME = 'scikit-tensor'
+DISTNAME = 'scikit-tensor-py3'
 DESCRIPTION = """Python module for multilinear algebra and tensor factorizations"""
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
     LONG_DESCRIPTION = f.read()


### PR DESCRIPTION
Undo 02952ff2a3e05fa95f5b5177e36fed9e257c8f25. `DISTNAME` in
`setup.py` should be unique and clear enough to distinguish it from
the origin package, and show it's a Python 3 release.