### PR TITLE
Fix failing Sphinx build by replacing pngmath with mathjax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ import sphinx_rtd_theme
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'numpydoc'


### PR DESCRIPTION
The Sphinx pngmath extension is not installed. From the Sphinx
documentation, it looks like this has been replaced by the imgmath
extension, but since that requires LaTeX and we're only producing HTML
documentation at the moment, it is easier to replace pngmath by
mathjax than by imgmath.